### PR TITLE
Set before property to none for .fa-home and .icon-home

### DIFF
--- a/readthedocs/fiware_readthedocs.css
+++ b/readthedocs/fiware_readthedocs.css
@@ -13,7 +13,7 @@ h4{color:#00275a !important;font-family:"Neo Tech W02 Medium" !important}
 a{color:#00275a !important}
 a:hover{color:#5dc0cf !important}
 a.icon-home{color:#fff !important;font-family:"Neo Tech W02 light" !important; font-weight:normal !important;color:#aeadb3 !important; text-transform:uppercase !important; margin:0 0 0 0 !important}
-.fa-home:before, .icon-home:before{content:url('imgs/logo_orion_nuevo.png') !important}
+.fa-home:before, .icon-home:before{content:None !important}
 .wy-menu-vertical {background-color:#f5f5f5 !important}
 .wy-menu-vertical li.current a{background-color:#b1b2b4 !important;border-right:0 !important}
 .wy-menu-vertical li.current a:hover{background-color:#b1b2b4 !important;border-right:0 !important}


### PR DESCRIPTION
This PR fixes an error that tried to load a non-existent image before the title.
